### PR TITLE
Allow user to build in a different directory from the source directory.

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -26,7 +26,7 @@ foreach(componentXmlFile ${component_xml_files})
     list(GET componentXmlFile 2 varnamEngineName)
     list(GET componentXmlFile 3 varnamEngineDescription)
     configure_file(varnam.xml.in varnam.${varnamLangCode}.xml)
-    install(FILES varnam.${varnamLangCode}.xml DESTINATION /usr/share/ibus/component)
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/varnam.${varnamLangCode}.xml DESTINATION /usr/share/ibus/component) #In case the user is building in a different directory from the source directory.
 endforeach(componentXmlFile)
 
 set(engine_executable_name ibus-engine-varnam)


### PR DESCRIPTION
I ran into this issue while building libvarnam-ibus in a directory different from the source directory. This is nice if you want to build directly from a clone git repo without cluttering it up.